### PR TITLE
Update Fluent Auth styles for better consistency

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -388,7 +388,7 @@ class Helper
 
     public static function getCssVariables()
     {
-        return [
+        $variables = [
             // Colors
             'fls-primary' => '#0275ff',
             'fls-primary-hover' => '#006799',
@@ -418,6 +418,8 @@ class Helper
             'fls-border-radius' => '5px',
             'fls-box-shadow' => '0 1px 3px rgb(0 0 0 / 4%)',
         ];
+
+        return apply_filters('fluent_auth/css_variables', $variables);
     }
 
     public static function renderCssVariables()

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -256,13 +256,13 @@ class Helper
 
         if ($context == 'edit') {
             if ($settings['google_key_method'] == 'wp_config') {
-                $settings['google_client_id'] = defined('\FLUENT_AUTH_GOOGLE_CLIENT_ID') ? \FLUENT_AUTH_GOOGLE_CLIENT_ID : '';
-                $settings['google_client_secret'] = defined('\FLUENT_AUTH_GOOGLE_CLIENT_SECRET') ? \FLUENT_AUTH_GOOGLE_CLIENT_SECRET : '';
+                $settings['google_client_id'] = (defined('FLUENT_AUTH_GOOGLE_CLIENT_ID')) ? FLUENT_AUTH_GOOGLE_CLIENT_ID : '';
+                $settings['google_client_secret'] = (defined('FLUENT_AUTH_GOOGLE_CLIENT_SECRET')) ? FLUENT_AUTH_GOOGLE_CLIENT_SECRET : '';
             }
 
             if ($settings['github_key_method'] == 'wp_config') {
-                $settings['github_client_id'] = defined('\FLUENT_AUTH_GITHUB_CLIENT_ID') ? \FLUENT_AUTH_GITHUB_CLIENT_ID : '';
-                $settings['github_client_secret'] = defined('\FLUENT_AUTH_GITHUB_CLIENT_SECRET') ? \FLUENT_AUTH_GITHUB_CLIENT_SECRET : '';
+                $settings['github_client_id'] = (defined('FLUENT_AUTH_GITHUB_CLIENT_ID')) ? FLUENT_AUTH_GITHUB_CLIENT_ID : '';
+                $settings['github_client_secret'] = (defined('FLUENT_AUTH_GITHUB_CLIENT_SECRET')) ? FLUENT_AUTH_GITHUB_CLIENT_SECRET : '';
             }
         }
 

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -224,7 +224,6 @@ class Helper
             ->where('status', '!=', 'issued')
             ->where('created_at', '<', $dateTime)
             ->delete();
-
     }
 
     public static function getSocialAuthSettings($context = 'view')
@@ -257,13 +256,13 @@ class Helper
 
         if ($context == 'edit') {
             if ($settings['google_key_method'] == 'wp_config') {
-                $settings['google_client_id'] = (defined('FLUENT_AUTH_GOOGLE_CLIENT_ID')) ? FLUENT_AUTH_GOOGLE_CLIENT_ID : '';
-                $settings['google_client_secret'] = (defined('FLUENT_AUTH_GOOGLE_CLIENT_SECRET')) ? FLUENT_AUTH_GOOGLE_CLIENT_SECRET : '';
+                $settings['google_client_id'] = defined('\FLUENT_AUTH_GOOGLE_CLIENT_ID') ? \FLUENT_AUTH_GOOGLE_CLIENT_ID : '';
+                $settings['google_client_secret'] = defined('\FLUENT_AUTH_GOOGLE_CLIENT_SECRET') ? \FLUENT_AUTH_GOOGLE_CLIENT_SECRET : '';
             }
 
             if ($settings['github_key_method'] == 'wp_config') {
-                $settings['github_client_id'] = (defined('FLUENT_AUTH_GITHUB_CLIENT_ID')) ? FLUENT_AUTH_GITHUB_CLIENT_ID : '';
-                $settings['github_client_secret'] = (defined('FLUENT_AUTH_GITHUB_CLIENT_SECRET')) ? FLUENT_AUTH_GITHUB_CLIENT_SECRET : '';
+                $settings['github_client_id'] = defined('\FLUENT_AUTH_GITHUB_CLIENT_ID') ? \FLUENT_AUTH_GITHUB_CLIENT_ID : '';
+                $settings['github_client_secret'] = defined('\FLUENT_AUTH_GITHUB_CLIENT_SECRET') ? \FLUENT_AUTH_GITHUB_CLIENT_SECRET : '';
             }
         }
 
@@ -385,5 +384,55 @@ class Helper
             }
             return false;
         }
+    }
+
+    public static function getCssVariables()
+    {
+        return [
+            // Colors
+            'fls-primary' => '#0275ff',
+            'fls-primary-hover' => '#006799',
+            'fls-primary-light' => '#0275ff91',
+            'fls-secondary' => '#4b5d73',
+            'fls-white' => '#fff',
+            'fls-gray' => '#777',
+            'fls-border-color' => '#c3c4c7',
+            'fls-error' => '#f56c6c',
+
+            // Typography
+            'fls-font-size-base' => '16px',
+
+            // Spacing
+            'fls-spacing-base' => '15px',
+            'fls-spacing-lg' => '24px',
+            'fls-spacing-xl' => '26px',
+            'fls-spacing-between' => '20px',
+
+            // Layout
+            'fls-max-width' => '500px',
+            'fls-gap' => '20px',
+            'fls-form-gap' => '15px',
+            'fls-input-gap' => '10px',
+
+            // Border & Shadow
+            'fls-border-radius' => '5px',
+            'fls-box-shadow' => '0 1px 3px rgb(0 0 0 / 4%)',
+        ];
+    }
+
+    public static function renderCssVariables()
+    {
+        $variables = self::getCssVariables();
+        $css = '';
+
+        foreach ($variables as $name => $value) {
+            $css .= "--{$name}: {$value};";
+        }
+
+        $styles = sprintf(':root {%s}', $css);
+
+        wp_register_style('fls-css-variables', false); // No actual file
+        wp_enqueue_style('fls-css-variables');
+        wp_add_inline_style('fls-css-variables', $styles);
     }
 }

--- a/app/Hooks/Handlers/CustomAuthHandler.php
+++ b/app/Hooks/Handlers/CustomAuthHandler.php
@@ -73,7 +73,8 @@ class CustomAuthHandler
         }
 
         if (get_current_user_id()) {
-            $message = apply_filters('fluent_auth/already_logged_in_message',
+            $message = apply_filters(
+                'fluent_auth/already_logged_in_message',
                 sprintf(__('You are already logged in. <a href="%s">Go to Home Page</a>', 'fluent-security'), site_url())
             );
             return '<p>' . $message . '</p>';
@@ -116,7 +117,7 @@ class CustomAuthHandler
         $return .= $this->nativeLoginForm($loginArgs);
 
         if ($attributes['show-signup'] == 'true' && get_option('users_can_register')) {
-            $return .= '<p style="text-align: center">'
+            $return .= '<p>'
                 . __('Not registered?', 'fluent-security')
                 . ' <a href="#" id="fls_show_signup">'
                 . __('Create an Account', 'fluent-security')
@@ -124,7 +125,7 @@ class CustomAuthHandler
         }
 
         if ($attributes['show-reset-password'] == 'true') {
-            $return .= '<p style="text-align: center">'
+            $return .= '<p>'
                 . __('Forgot your password?', 'fluent-security')
                 . ' <a href="#" id="fls_show_reset_password">'
                 . __('Reset Password', 'fluent-security')
@@ -151,7 +152,8 @@ class CustomAuthHandler
         }
 
         if (get_current_user_id()) {
-            $message = apply_filters('fluent_auth/already_logged_in_message',
+            $message = apply_filters(
+                'fluent_auth/already_logged_in_message',
                 sprintf(__('You are already logged in. <a href="%s">Go to Home Page</a>', 'fluent-security'), site_url())
             );
             return '<p>' . $message . '</p>';
@@ -193,7 +195,7 @@ class CustomAuthHandler
         $registrationForm .= apply_filters('fluent_auth/after_registration_form_close', '', $registrationFields, $attributes);
 
         if ($hide) {
-            $registrationForm .= '<p style="text-align: center">'
+            $registrationForm .= '<p>'
                 . __('Already have an account?', 'fluent-security')
                 . ' <a href="#" id="fls_show_login">'
                 . __('Login', 'fluent-security')
@@ -212,7 +214,8 @@ class CustomAuthHandler
         }
 
         if (get_current_user_id()) {
-            $message = apply_filters('fluent_auth/already_logged_in_message',
+            $message = apply_filters(
+                'fluent_auth/already_logged_in_message',
                 sprintf(__('You are already logged in. <a href="%s">Go to Home Page</a>', 'fluent-security'), site_url())
             );
             return '<p>' . $message . '</p>';
@@ -267,7 +270,8 @@ class CustomAuthHandler
         }
 
         if (get_current_user_id()) {
-            $message = apply_filters('fluent_auth/already_logged_in_message',
+            $message = apply_filters(
+                'fluent_auth/already_logged_in_message',
                 sprintf(__('You are already logged in. <a href="%s">Go to Home Page</a>', 'fluent-security'), site_url())
             );
             return '<p>' . $message . '</p>';
@@ -297,10 +301,11 @@ class CustomAuthHandler
         }
 
         if (get_current_user_id()) {
-            $message = apply_filters('fluent_auth/already_logged_in_message',
+            $message = apply_filters(
+                'fluent_auth/already_logged_in_message',
                 sprintf(__('You are already logged in. <a href="%s">Go to Home Page</a>', 'fluent-security'), site_url())
             );
-            return '<p>' . $message . '</p>';
+            return sprintf('<p>%s</p>', $message);
         }
 
         $atts = $this->getShortcodes($attributes);
@@ -308,7 +313,7 @@ class CustomAuthHandler
         $magicHandler->pushAssets();
 
         ob_start();
-        ?>
+?>
         <div id="fls_magic_login">
             <div class="fls_magic_login_form fls_magic_login">
                 <?php if ($content): ?>
@@ -320,11 +325,11 @@ class CustomAuthHandler
                     <?php _e('Your Email/Username', 'fluent-security'); ?>
                 </label>
                 <input placeholder="<?php _e('Your Email/Username', 'fluent-security'); ?>" id="fls_magic_logon"
-                       class="fls_magic_input" type="text"/>
+                    class="fls_magic_input" type="text" />
                 <input id="fls_magic_logon_nonce" type="hidden"
-                       value="<?php echo wp_create_nonce('fls_magic_send_magic_email'); ?>"/>
+                    value="<?php echo wp_create_nonce('fls_magic_send_magic_email'); ?>" />
                 <?php if (!empty($atts['redirect_to'])): ?>
-                    <input type="hidden" value="<?php echo esc_url($atts['redirect_to']); ?>" name="redirect_to"/>
+                    <input type="hidden" value="<?php echo esc_url($atts['redirect_to']); ?>" name="redirect_to" />
                 <?php endif; ?>
                 <div class="fls_magic_submit_wrapper">
                     <button class="button button-primary button-large" id="fls_magic_submit">
@@ -514,14 +519,14 @@ class CustomAuthHandler
                     return;
                 }
 
-                ?>
+        ?>
                 <script type="text/javascript">
-                    document.addEventListener("DOMContentLoaded", function () {
+                    document.addEventListener("DOMContentLoaded", function() {
                         var redirect = "<?php echo esc_url($redirect); ?>";
                         window.location.replace(redirect);
                     });
                 </script>
-                <?php
+        <?php
             }
             die();
         }
@@ -532,6 +537,8 @@ class CustomAuthHandler
         if ($this->loaded) {
             return false;
         }
+
+        Helper::renderCssVariables();
 
         wp_enqueue_script('fluent_auth_login_helper', FLUENT_AUTH_PLUGIN_URL . 'dist/public/login_helper.js', [], FLUENT_AUTH_VERSION);
         wp_localize_script('fluent_auth_login_helper', 'fluentAuthPublic', [
@@ -925,7 +932,6 @@ class CustomAuthHandler
             wp_send_json([
                 'message' => __('Security verification failed. Please try again', 'fluent-security')
             ], 422);
-
         }
 
         $usernameOrEmail = trim(wp_unslash(Arr::get($data, 'user_login')));
@@ -1127,10 +1133,10 @@ class CustomAuthHandler
         }
 
         $form = \sprintf(
-                '<form name="%1$s" id="%1$s" action="%2$s" method="post">',
-                esc_attr($args['form_id']),
-                $actionUrl
-            ) .
+            '<form name="%1$s" id="%1$s" action="%2$s" method="post">',
+            esc_attr($args['form_id']),
+            $actionUrl
+        ) .
             $login_form_top .
             \sprintf(
                 '<p class="login-username">
@@ -1242,26 +1248,26 @@ class CustomAuthHandler
         <div class="fls_signup_verification">
             <div class="fls_field_group fls_field_vefication">
                 <p><?php echo esc_html(sprintf(__('A verification code as been sent to %s. Please provide the code bellow: ', 'fluent-'), $formData['email'])) ?></p>
-                <input type="hidden" name="_email_verification_hash" value="<?php echo esc_attr($hash); ?>"/>
+                <input type="hidden" name="_email_verification_hash" value="<?php echo esc_attr($hash); ?>" />
                 <div class="fls_field_label is-required"><label
                         for="fls_field_vefication"><?php _e('Vefication Code', 'fluent-security'); ?></label></div>
                 <div class="fs_input_wrap"><input type="text" id="fls_field_vefication" placeholder=""
-                                                  name="_email_verification_token" required></div>
+                        name="_email_verification_token" required></div>
             </div>
             <button type="submit" id="fls_verification_submit">
                 <svg version="1.1" class="fls_loading_svg" x="0px" y="0px" width="40px" height="20px"
-                     viewBox="0 0 50 50" style="enable-background:new 0 0 50 50;" xml:space="preserve">
+                    viewBox="0 0 50 50" style="enable-background:new 0 0 50 50;" xml:space="preserve">
                     <path fill="currentColor"
-                          d="M43.935,25.145c0-10.318-8.364-18.683-18.683-18.683c-10.318,0-18.683,8.365-18.683,18.683h4.068c0-8.071,6.543-14.615,14.615-14.615c8.072,0,14.615,6.543,14.615,14.615H43.935z">
+                        d="M43.935,25.145c0-10.318-8.364-18.683-18.683-18.683c-10.318,0-18.683,8.365-18.683,18.683h4.068c0-8.071,6.543-14.615,14.615-14.615c8.072,0,14.615,6.543,14.615,14.615H43.935z">
                         <animateTransform attributeType="xml" attributeName="transform" type="rotate" from="0 25 25"
-                                          to="360 25 25" dur="0.6s" repeatCount="indefinite"></animateTransform>
+                            to="360 25 25" dur="0.6s" repeatCount="indefinite"></animateTransform>
                     </path>
                 </svg>
                 <span><?php _e('Complete Signup', 'fluent-security'); ?></span>
             </button>
         </div>
 
-        <?php
+<?php
         return ob_get_clean();
     }
 }

--- a/app/Hooks/Handlers/MagicLoginHandler.php
+++ b/app/Hooks/Handlers/MagicLoginHandler.php
@@ -38,7 +38,6 @@ class MagicLoginHandler
             }
 
             return $this->generateHash($user, $minutes);
-
         }, 10, 3);
         add_filter('fluent_auth/login_token_by_user_email', function ($hash, $emailId, $minutes) {
             if (!$this->isEnabled()) {
@@ -65,7 +64,7 @@ class MagicLoginHandler
         }
 
         $this->pushAssets();
-        ?>
+?>
         <div style="display: none;" id="fls_magic_login">
             <div class="fls_magic_initial">
                 <div class="fls_magic-or">
@@ -84,8 +83,8 @@ class MagicLoginHandler
                 <label for="fls_magic_logon">
                     <?php _e('Your Email/Username', 'fluent-security'); ?>
                 </label>
-                <input placeholder="<?php _e('Your Email/Username', 'fluent-security'); ?>" id="fls_magic_logon" class="fls_magic_input" type="text" name="fls_magic_logon_email"/>
-                <input id="fls_magic_logon_nonce" type="hidden" name="fls_magic_logon_nonce" value="<?php echo wp_create_nonce('fls_magic_logon_nonce'); ?>"/>
+                <input placeholder="<?php _e('Your Email/Username', 'fluent-security'); ?>" id="fls_magic_logon" class="fls_magic_input" type="text" name="fls_magic_logon_email" />
+                <input id="fls_magic_logon_nonce" type="hidden" name="fls_magic_logon_nonce" value="<?php echo wp_create_nonce('fls_magic_logon_nonce'); ?>" />
                 <div class="fls_magic_submit_wrapper">
                     <button class="button button-primary button-large" id="fls_magic_submit">
                         <?php _e('Continue', 'fluent-security'); ?>
@@ -104,7 +103,7 @@ class MagicLoginHandler
                 </div>
             </div>
         </div>
-        <?php
+<?php
     }
 
     public function maybeMagicFormOnLoginFunc($html)
@@ -125,6 +124,8 @@ class MagicLoginHandler
         if ($this->assetLoaded || !$this->isEnabled()) {
             return;
         }
+
+        Helper::renderCssVariables();
 
         wp_enqueue_script('fls_magic_url', FLUENT_AUTH_PLUGIN_URL . 'dist/public/fls_login.js', [], null, true);
 
@@ -180,7 +181,7 @@ class MagicLoginHandler
         // Let's prepare
         if (strpos($username, '@')) {
             $user = get_user_by('email', $username);
-            if(!$user) {
+            if (!$user) {
                 $user = get_user_by('login', $username);
             }
         } else {
@@ -223,7 +224,7 @@ class MagicLoginHandler
             __('If the button above does not work, paste this link into your web browser:', 'fluent-security'),
             esc_url($loginUrl),
             ' ',
-            __('If you did not make this request, you can safely ignore this email.','fluent-security')
+            __('If you did not make this request, you can safely ignore this email.', 'fluent-security')
         ];
 
         $emailBody = '';
@@ -372,7 +373,8 @@ class MagicLoginHandler
         Helper::setLoginMedia('magic_login');
 
         add_filter('authenticate', array($this, 'allowProgrammaticLogin'), 10, 3);    // hook in earlier than other callbacks to short-circuit them
-        $user = wp_signon(array(
+        $user = wp_signon(
+            array(
                 'user_login' => $user->user_login,
                 'user_password' => ''
             )
@@ -444,5 +446,4 @@ class MagicLoginHandler
 
         return !array_intersect($restrictedRoles, array_values($user->roles));
     }
-
 }

--- a/app/Hooks/Handlers/TwoFaHandler.php
+++ b/app/Hooks/Handlers/TwoFaHandler.php
@@ -199,7 +199,8 @@ class TwoFaHandler
         remove_action('fluent_auth/login_attempts_checked', [$this, 'maybe2FaRedirect'], 1);
 
         add_filter('authenticate', array($this, 'allowProgrammaticLogin'), 10, 3);    // hook in earlier than other callbacks to short-circuit them
-        $user = wp_signon(array(
+        $user = wp_signon(
+            array(
                 'user_login' => $user->user_login,
                 'user_password' => '',
                 'remember'   => (bool) strpos($logHash->login_hash, '-auth')
@@ -318,38 +319,32 @@ class TwoFaHandler
     private function get2FaFormHtml($data = [])
     {
         $redirectTo = Arr::get($data, 'redirect_to');
-
-        if($redirectTo) {
+        if ($redirectTo) {
             $redirectTo = esc_url_raw($redirectTo);
         }
 
         ob_start();
-        ?>
-        <form
-            style="margin-top: 20px;margin-left: 0;padding: 26px 24px 34px;font-weight: 400;overflow: hidden;background: #fff;border: 1px solid #c3c4c7;box-shadow: 0 1px 3px rgb(0 0 0 / 4%);"
-            class="fls_2fs" id="fls_2fa_form">
-            <input type="hidden" name="login_hash" value="<?php echo esc_attr(Arr::get($data, 'login_hash')); ?>"/>
-            <input type="hidden" name="redirect_to" value="<?php echo esc_attr($redirectTo); ?>"/>
+?>
+        <form class="fls_2fa" id="fls_2fa_form">
+            <input type="hidden" name="login_hash" value="<?php echo esc_attr(Arr::get($data, 'login_hash')); ?>" />
+            <input type="hidden" name="redirect_to" value="<?php echo esc_attr($redirectTo); ?>" />
             <div class="user-pass-wrap">
-                <p style="margin-bottom: 20px;"><?php _e('Please check your email inbox and get the 2 factor Authentication code and Provide here to login', 'fluent-security'); ?></p>
+                <p><?php _e('Please check your email inbox and get the 2 factor Authentication code and Provide here to login', 'fluent-security'); ?></p>
                 <label for="login_passcode"><?php _e('Two-Factor Authentication Code', 'fluent-security'); ?></label>
                 <div class="wp-pwd">
-                    <input style="font-size: 14px;" placeholder="<?php _e('Login Code', 'fluent-security'); ?>"
-                           type="text"
-                           value="<?php echo (isset($data['auto_code'])) ? esc_attr($data['auto_code']) : ''; ?>"
-                           name="login_passcode" id="login_passcode" class="input" size="20"/>
+                    <input placeholder="<?php _e('Login Code', 'fluent-security'); ?>"
+                        type="text"
+                        value="<?php echo (isset($data['auto_code'])) ? esc_attr($data['auto_code']) : ''; ?>"
+                        name="login_passcode" id="login_passcode" class="input" size="20" />
                 </div>
                 <div>
-                    <button
-                        style="display: block; cursor: pointer; width: 100%;border: 1px solid #2271b1;background: #2271b1;color: #fff;text-decoration: none;text-shadow: none;min-height: 32px;line-height: 2.30769231;padding: 4px 12px;font-size: 13px;border-radius: 3px;"
-                        id="fls_2fa_confirm" type="submit">
+                    <button id="fls_2fa_confirm" type="submit">
                         <?php _e('Login', 'fluent-security'); ?>
                     </button>
                 </div>
             </div>
         </form>
-        <?php
-
+<?php
         return ob_get_clean();
     }
 }

--- a/src/public/login_helper.scss
+++ b/src/public/login_helper.scss
@@ -1,223 +1,384 @@
-.fls_login_wrapper{
-    max-width: 500px;
-    form#loginform > p, #fls_2fa_form > p {
-        display: block;
-        margin-bottom: 15px;
-    }
+/**
+ * FluentAuth Login Helper Styles
+ * Base styles and common components for authentication forms
+ */
 
-    #fls_2fa_form {
-        .wp-pwd {
-            margin-bottom: 20px;
-        }
-    }
-
-    form#loginform label, #fls_2fa_form label {
-        display: block;
-        font-weight: 500;
-    }
-
-    form#loginform .input, #fls_2fa_form .input {
-        padding: 10px;
-        width: 100%;
-        margin-top: 10px;
-    }
-
-
-    form#loginform, #fls_2fa_form {
-        display: block;
-        overflow: hidden;
-        width: 100%;
-        box-sizing: border-box;
-    }
-
-    input#wp-submit {
-        width: 100%;
-        padding: 15px;
-        background: #0275ff;
-        color: white;
-        border: 0;
-        border-radius: 5px;
-    }
+// Base Form Components
+.fls-form-group {
+  margin-bottom: var(--fls-spacing-between);
 }
 
-.fls_registration_wrapper {
-    max-width: 500px;
-
-    .fls_registration_form {
-        display: grid;
-
-        .fls_field_group {
-            display: block;
-            margin-bottom: 15px;
-            .fls_field_label {
-                &.is-required {
-                    label:after {
-                        content: " *";
-                        color: #f56c6c;
-                        margin-left: 3px;
-                    }
-                }
-            }
-
-            &.is-error {
-                input {
-                    border-color: #f56c6c;
-                }
-            }
-        }
-
-        input {
-            padding: 10px;
-            width: 100%;
-            margin-top: 10px;
-        }
-
-        #fls_submit,#fls_verification_submit {
-            width: 100%;
-            padding: 15px;
-            background: #0275ff;
-            color: white;
-            border: 0;
-            border-radius: 5px;
-
-            span {
-                transition: all 1s;
-                opacity: 1;
-            }
-
-            svg {
-                display: none;
-                margin: 0 auto;
-                transition: all 1s;
-
-                path, rect {
-                    fill: white;
-                    transition: initial;
-                }
-            }
-
-            &.fls_loading {
-                background: #0275ff91;
-
-                span {
-                    display: none;
-                    opacity: 0;
-                }
-
-                svg {
-                    display: block;
-                    opacity: 1;
-                }
-            }
-        }
-    }
-
-    .fls_signup_verification {
-        margin-bottom: 30px;
-    }
+// Common Input & Button Base Styles
+%form-element-base {
+  width: 100%;
+  padding: var(--fls-spacing-base);
+  font-size: var(--fls-font-size-base);
+  border-radius: var(--fls-border-radius);
+  box-sizing: border-box;
+  margin: 0;
 }
 
+// Input Base
+.fls-input {
+  @extend %form-element-base;
+  border: 1px solid var(--fls-border-color);
+
+  &:focus {
+    outline: none;
+    border-color: var(--fls-primary);
+  }
+}
+
+// Button Base
+.fls-button {
+  @extend %form-element-base;
+  background: var(--fls-primary);
+  color: var(--fls-white);
+  border: none;
+  cursor: pointer;
+  transition: background 0.3s ease;
+
+  &:is(:hover, :focus) {
+    background: var(--fls-primary-hover);
+  }
+
+  // Secondary Button Variant
+  &.fls-button-secondary {
+    background: var(--fls-white);
+    border: 1px solid var(--fls-border-color);
+    color: var(--fls-gray);
+
+    &:is(:hover, :focus) {
+      background: var(--fls-secondary);
+      color: var(--fls-white);
+    }
+  }
+}
+
+// Common Form Layout
+%form-container {
+  max-width: var(--fls-max-width);
+  width: 100%;
+  margin: 0 auto;
+}
+
+%form-layout {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fls-form-gap);
+}
+
+%label-style {
+  display: block;
+  font-weight: 500;
+  margin-bottom: 0;
+}
+
+// Form Wrappers
+.fls_login_wrapper {
+  @extend %form-container;
+
+  form#loginform {
+    @extend %form-layout;
+  }
+
+  // Form Elements
+  input[type='text'],
+  input[type='password'],
+  input[type='email'],
+  input#wp-submit {
+    @extend .fls-input;
+  }
+
+  input#wp-submit {
+    @extend .fls-button;
+  }
+
+  label {
+    @extend %label-style;
+  }
+
+  // Reset margins for form groups
+  .login-username,
+  .login-password,
+  .login-remember,
+  .login-submit {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--fls-input-gap);
+  }
+
+  & > p {
+    text-align: center;
+  }
+
+  & p:has(+ p) {
+    margin-bottom: var(--fls-spacing-base);
+  }
+
+  // WordPress password field wrapper
+  .user-pass-wrap {
+    label {
+      margin-bottom: var(--fls-input-gap);
+    }
+
+    .wp-pwd {
+      margin-bottom: var(--fls-spacing-base);
+    }
+  }
+}
+
+// Registration & Reset Password Forms
+.fls_registration_wrapper,
 .fls_reset_pass_wrapper {
-    max-width: 500px;
-    .fls_reset_pass_form {
-        display: grid;
+  @extend %form-container;
 
-        .fls_field_group {
-            display: block;
-            margin-bottom: 15px;
+  form {
+    @extend %form-layout;
+  }
 
-            .fls_field_label {
-                &.is-required {
-                    label:after {
-                        content: " *";
-                        color: #f56c6c;
-                        margin-left: 3px;
-                    }
-                }
-            }
+  .fls_registration_fields {
+    @extend %form-layout;
+  }
 
-            &.is-error {
-                input {
-                    border-color: #f56c6c;
-                }
-            }
-        }
+  .fls_field_group {
+    @extend %form-layout;
+    gap: var(--fls-input-gap);
+    margin: 0;
 
-        input {
-            padding: 10px;
-            width: 100%;
-            margin-top: 10px;
-        }
-
-        #fls_reset_pass {
-            width: 100%;
-            padding: 15px;
-            background: #0275ff;
-            color: white;
-            border: 0;
-            border-radius: 5px;
-
-            span {
-                transition: all 1s;
-                opacity: 1;
-            }
-
-            svg {
-                display: none;
-                margin: 0 auto;
-                transition: all 1s;
-
-                path, rect {
-                    fill: white;
-                    transition: initial;
-                }
-            }
-
-            &.fls_loading {
-                background: #0275ff91;
-
-                span {
-                    display: none;
-                    opacity: 0;
-                }
-
-                svg {
-                    display: block;
-                    opacity: 1;
-                }
-            }
-        }
+    .fls_field_label {
+      margin: 0;
     }
-    .success.text-success {
-        margin-top: 15px;
-        text-align: center;
+  }
+
+  & > p {
+    text-align: center;
+    margin-top: var(--fls-spacing-base);
+  }
+
+  // Form Elements
+  input[type='text'],
+  input[type='password'],
+  input[type='email'] {
+    @extend .fls-input;
+  }
+
+  label {
+    @extend %label-style;
+  }
+
+  // Submit Buttons
+  #fls_submit,
+  #fls_verification_submit,
+  #fls_reset_pass {
+    @extend .fls-button;
+    @extend %button-loading;
+
+    &:is(:hover, :focus) {
+      background: var(--fls-primary-hover);
     }
+  }
 }
 
+// Error & Success Messages
 .error.text-danger {
-    font-size: 12px;
-    margin-top: 4px;
-    color: #f56c6c;
+  font-size: var(--fls-font-size-base);
+  color: var(--fls-error);
+  text-align: center;
+  margin-bottom: var(--fls-spacing-base);
 }
 
+.success.text-success {
+  margin-top: var(--fls-spacing-base);
+  text-align: center;
+}
+
+// Auth Wrapper
 .fls_auth_wrapper {
-    .hide {
-        display: none;
-    }
+  @extend %form-layout;
+  gap: var(--fls-gap);
 
-    #fls_submit {
-        margin-bottom: 15px;
-    }
+  p {
+    font-size: var(--fls-font-size-base);
+  }
+
+  .hide {
+    display: none;
+  }
 }
 
+// Loading States
+.fls_loading {
+  opacity: 0.7 !important;
+  cursor: wait !important;
+}
 
 button#fls_2fa_confirm.fls_loading {
-    background: gray !important;
-    border-color: gray !important;
-    color: white !important;
+  background: var(--fls-gray) !important;
+  border-color: var(--fls-gray) !important;
+  color: var(--fls-white) !important;
 }
 
-.fls_loading {
-    opacity: 0.7 !important;
-    cursor: wait !important;
+// Magic Login Styles
+#fls_magic_login {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fls-form-gap);
+
+  .fls_magic_login_form {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    max-width: var(--fls-max-width);
+    width: 100%;
+    margin-inline: auto;
+
+    label {
+      margin-bottom: var(--fls-input-gap);
+    }
+
+    .fls_magic_input,
+    .fls_magic_submit_wrapper {
+      margin-bottom: var(--fls-form-gap);
+    }
+  }
+
+  .fls_magic_content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--fls-input-gap);
+  }
+}
+
+// Links container
+.fls_auth_links {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fls-input-gap);
+  text-align: center;
+  margin-top: var(--fls-form-gap);
+}
+
+// Loading state adjustments
+.fls_loading_svg {
+  margin: 0 auto;
+}
+
+// Remove any leftover margin/padding that might interfere with gap
+.fls_field_label,
+.fs_input_wrap,
+.fls_magic_submit_wrapper,
+.magic_back_regular {
+  margin: 0;
+  padding: 0;
+}
+
+.magic_back_regular .fls_magic-or {
+  margin-bottom: 0;
+}
+
+// Common Button Styles
+[class*='fls_'] {
+  button,
+  input[type='submit'] {
+    @extend .fls-button;
+    @extend %button-loading;
+
+    &:is(:hover, :focus) {
+      background: var(--fls-primary-hover);
+    }
+
+    // Secondary variant
+    &.magic_btn_secondary,
+    &.fls-button-secondary {
+      background: var(--fls-white);
+      border: 1px solid var(--fls-border-color);
+      color: var(--fls-gray);
+
+      &:is(:hover, :focus) {
+        background: var(--fls-secondary);
+        color: var(--fls-white);
+      }
+    }
+  }
+}
+
+// Loading State Styles
+%button-loading {
+  span {
+    transition: all 1s;
+    opacity: 1;
+  }
+
+  svg {
+    display: none;
+    margin: 0 auto;
+    transition: all 1s;
+
+    path,
+    rect {
+      fill: var(--fls-white);
+      transition: initial;
+    }
+  }
+
+  &.fls_loading {
+    background: var(--fls-primary-light);
+
+    span {
+      display: none;
+      opacity: 0;
+    }
+
+    svg {
+      display: block;
+      opacity: 1;
+    }
+  }
+}
+
+// Two Factor Authentication Form
+.fls_2fa {
+  @extend %form-container;
+  margin-top: var(--fls-spacing-xl);
+  padding: var(--fls-spacing-xl) var(--fls-spacing-lg);
+  font-weight: 400;
+  overflow: hidden;
+  background: var(--fls-white);
+  border: 1px solid var(--fls-border-color);
+  border-radius: var(--fls-border-radius);
+  box-shadow: var(--fls-box-shadow);
+
+  .user-pass-wrap {
+    @extend %form-layout;
+    gap: 0;
+
+    p {
+      margin-bottom: var(--fls-spacing-xl);
+    }
+
+    input {
+      @extend .fls-input;
+    }
+
+    label {
+      @extend %label-style;
+    }
+
+    .wp-pwd {
+      margin-bottom: var(--fls-form-gap);
+    }
+  }
+
+  #fls_2fa_confirm {
+    @extend .fls-button;
+    @extend %button-loading;
+
+    &.fls_loading {
+      background: var(--fls-gray) !important;
+      border-color: var(--fls-gray) !important;
+      color: var(--fls-white) !important;
+    }
+  }
 }

--- a/src/public/magic_url.scss
+++ b/src/public/magic_url.scss
@@ -1,27 +1,47 @@
+/**
+ * FluentAuth Magic URL Styles
+ * Styles specific to the magic login functionality
+ */
+
+// Import base styles
+@import 'login_helper';
+
+// Magic Login Container
 div#fls_magic_login {
   display: block;
   clear: both;
-  margin-top: 20px;
+
+  input {
+    @extend .fls-input;
+  }
 }
 
-#login form p.submit {
-  clear: both;
-  overflow: hidden;
+// Magic Login Form
+.fls_magic_login_form {
+  @extend %form-layout;
+  @extend %form-container;
+
+  label {
+    @extend %label-style;
+  }
 }
 
+// Divider
 .fls_magic-or {
-  margin-bottom: 16px;
+  margin-bottom: var(--fls-form-gap);
   position: relative;
   text-align: center;
+
   span {
-    background: #fff;
-    color: #777;
+    background: var(--fls-white);
+    color: var(--fls-gray);
     position: relative;
-    padding: 0 8px;
+    padding: 0 var(--fls-spacing-base);
     text-transform: uppercase;
   }
+
   &:before {
-    background: #E5E5E5;
+    background: var(--fls-border-color);
     content: '';
     height: 1px;
     position: absolute;
@@ -31,27 +51,17 @@ div#fls_magic_login {
   }
 }
 
-
-
-.fls_magic_show_btn, #fls_magic_submit {
-  cursor: pointer;
-  display: block;
-  width: 100%;
-  padding: 5px 15px;
-  color: white;
-  border: 0;
-  border-radius: 5px;
-  min-height: 32px;
-}
-.fls_magic_show_btn, {
-  padding: 10px 15px;
+// Magic Login Buttons
+.fls_magic_show_btn,
+#fls_magic_submit {
+  @extend .fls-button;
 }
 
-.fls_magic_show_btn:hover, #fls_magic_submit:hover {
-  background: #006799;
-  border-radius: 5px;
+#fls_magic_submit:is(:hover, :focus) {
+  background: var(--fls-primary-hover);
 }
 
+// Form States
 #loginform.showing_magic_form > {
   * {
     display: none !important;
@@ -61,51 +71,45 @@ div#fls_magic_login {
   }
 }
 
-p.fls_magic_text {
-  margin-bottom: 10px !important;
-  font-size: 15px;
-}
-
+// Success States
 .login_magic_success {
   text-align: center;
+
   img {
     width: 48px;
-    margin-bottom: 10px;
+    margin-bottom: var(--fls-spacing-base);
   }
 }
 
 .login_success_heading {
-  font-size: 20px;
-  margin-bottom: 15px;
+  font-size: calc(var(--fls-font-size-base) * 1.4);
+  margin-bottom: var(--fls-spacing-base);
 }
 
 .login_success_message {
-  font-size: 14px;
+  font-size: var(--fls-font-size-base);
 }
 
+// Back Button Section
 .magic_back_regular {
-  margin-top: 30px;
+  @extend %form-layout;
+
+  .fls_magic-or {
+    margin-bottom: 0;
+  }
 }
 
+// Secondary Button
 .magic_btn_secondary {
-  width: 100%;
-  padding: 10px;
-  background-color: white;
-  border: 1px solid gray;
-  cursor: pointer;
-  color: black;
-  border-radius: 5px;
-  &:hover {
-    background: #4b5d73;
-    color: white;
-  }
+  @extend .fls-button;
+  @extend .fls-button-secondary;
 }
 
 #fls_magic_logon {
   display: block;
   width: 100%;
-  margin: 10px 0px;
-  font-size: 14px;
+  margin: var(--fls-spacing-base) 0;
+  font-size: var(--fls-font-size-base);
 }
 
 .fls_magic_submit_wrapper {
@@ -114,5 +118,13 @@ p.fls_magic_text {
 }
 
 #fls_magic_login {
-  margin-bottom: 10px;
+  margin-bottom: var(--fls-spacing-base);
+}
+
+// Reset margins since we're using gap
+.fls_magic_show_btn,
+#fls_magic_submit,
+.magic_btn_secondary,
+#fls_magic_logon {
+  margin: 0;
 }


### PR DESCRIPTION
This PR refactors a bunch of the Fluent Auth form styling.

Changes:
- Adds css variables for easier overriding and maintaining consistency
- Refactors styles in `login_helper.scss` and `magic_url.scss`
- Removes a bunch of inline style tags and converts them to static css
- Filter to modify the css variables

**After & Before**
- Left is After, Right is Before
- New styling auto centers forms to middle of page and sets consistent max width

![Screenshot 2025-02-24 at 17 24 23](https://github.com/user-attachments/assets/b5d1bea7-1f33-42b6-82dd-0b23dfcfccb9)
![Screenshot 2025-02-24 at 17 24 35](https://github.com/user-attachments/assets/62795665-a3de-4603-9c47-313bf994638a)
![Screenshot 2025-02-24 at 17 24 46](https://github.com/user-attachments/assets/b217e719-e839-438f-8198-47418151d7b1)
![Screenshot 2025-02-24 at 17 25 00](https://github.com/user-attachments/assets/0b66e00c-405d-490d-b46b-64047cb7d377)
