### PR TITLE
Fix magic login shortcode nonce mismatch

### DIFF
--- a/app/Hooks/Handlers/CustomAuthHandler.php
+++ b/app/Hooks/Handlers/CustomAuthHandler.php
@@ -340,7 +340,7 @@ class CustomAuthHandler
                 <input placeholder="<?php _e('Your Email/Username', 'fluent-security'); ?>" id="fls_magic_logon"
                        class="fls_magic_input" type="text"/>
                 <input id="fls_magic_logon_nonce" type="hidden"
-                       value="<?php echo wp_create_nonce('fls_magic_send_magic_email'); ?>"/>
+                       value="<?php echo wp_create_nonce('fls_magic_logon_nonce'); ?>"/>
                 <?php if (!empty($atts['redirect_to'])): ?>
                     <input type="hidden" value="<?php echo esc_url($atts['redirect_to']); ?>" name="redirect_to"/>
                 <?php endif; ?>


### PR DESCRIPTION
Fix magic login nonce validation issue happens when using the [fluent_auth_magic_login] shortcode.