### PR TITLE
Fix typo in filter name: extra_login_page_wrap_css_class

### DIFF
--- a/app/Hooks/Handlers/LoginCustomizerHandler.php
+++ b/app/Hooks/Handlers/LoginCustomizerHandler.php
@@ -132,7 +132,7 @@ class LoginCustomizerHandler
 
         add_action('login_header', function () use ($formSettings, $formType) {
 
-            $extraCssClass = apply_filters('fluent_auth/extra_ogin_page_wrap_css_class', '');
+            $extraCssClass = apply_filters('fluent_auth/extra_login_page_wrap_css_class', '');
             $extraCssClass .= 'fls_layout_banner_' . Arr::get($formSettings, 'banner.position');
 
             ?>


### PR DESCRIPTION
Fixed typo in filter name: extra_login_page_wrap_css_class 