### PR TITLE
Fix timezone mismatch in quickStats and log time diff

### DIFF
--- a/app/Http/Controllers/LogsController.php
+++ b/app/Http/Controllers/LogsController.php
@@ -40,9 +40,10 @@ class LogsController
 
         $logs = $query->paginate();
 
-        $currentTimeStamp = current_time('timestamp');
+        $wpTimestamp = current_time('timestamp');
+        $utcOffset = $wpTimestamp - time();
         foreach ($logs['data'] as $log) {
-            $log->human_time_diff = human_time_diff(strtotime($log->created_at, $currentTimeStamp), $currentTimeStamp) . ' ago';
+            $log->human_time_diff = human_time_diff(strtotime($log->created_at) + $utcOffset, $wpTimestamp) . ' ago';
         }
 
         return [
@@ -80,15 +81,17 @@ class LogsController
             $fromRange = '-0 days';
         }
 
+        $wpTimestamp = current_time('timestamp');
+
         if ($fromRange == 'this_month') {
-            $fromDate = date('Y-m-01 00:00:00');
+            $fromDate = date('Y-m-01 00:00:00', $wpTimestamp);
         } else if ($fromRange == 'all_time') {
             $fromDate = '1970-01-01 00:00:00';
         } else {
-            $fromDate = date('Y-m-d 00:00:00', strtotime($fromRange));
+            $fromDate = date('Y-m-d 00:00:00', strtotime($fromRange, $wpTimestamp));
         }
 
-        $toDate = date('Y-m-d 23:59:59', current_time('timestamp'));
+        $toDate = date('Y-m-d 23:59:59', $wpTimestamp);
 
         $counts = flsDb()->table('fls_auth_logs')
             ->select(['status', flsDb()->raw('count(*) as total')])


### PR DESCRIPTION
Use WordPress timezone consistently for both fromDate and toDate in quickStats, and adjust strtotime offset in human_time_diff calculation.