### PR TITLE
fix/digest-email-fix-and-supported-all-other-option

### DIFF
--- a/app/Hooks/Handlers/BasicTasksHandler.php
+++ b/app/Hooks/Handlers/BasicTasksHandler.php
@@ -151,7 +151,7 @@ class BasicTasksHandler
         $frequency = Helper::getSetting('digest_summary');
         $adminEmail = Helper::getSetting('notification_email');
 
-        if (!$frequency || !$adminEmail) {
+        if (!$frequency || $frequency == 'none' || !$adminEmail) {
             return false;
         }
 
@@ -160,34 +160,53 @@ class BasicTasksHandler
             return false;
         }
 
-        if ($frequency == 'monthly' && date('d') != '01') {
-            return false;
-        }
-
-        if ($frequency == 'weekly' && date('D') != 'Mon') {
-            return false;
-        }
-
-        $cutOuts = [
-            'daily'   => 23 * HOUR_IN_SECONDS,
-            'weekly'  => 6 * DAY_IN_SECONDS,
-            'monthly' => 27 * DAY_IN_SECONDS
+        $currentTimestamp = current_time('timestamp');
+        $weekDays = [
+            'sun' => 0,
+            'mon' => 1,
+            'tue' => 2,
+            'wed' => 3,
+            'thu' => 4,
+            'fri' => 5,
+            'sat' => 6,
         ];
 
-        $cutOut = (isset($cutOuts[$frequency])) ? $cutOuts[$frequency] : 0;
+        if ($frequency == 'daily') {
+            $cutOut = 23 * HOUR_IN_SECONDS;
+            $period = 'daily';
+        } else if ($frequency == 'monthly') {
+            if (date('d', $currentTimestamp) != '01') {
+                return false;
+            }
 
-        if (!$cutOut) {
+            $cutOut = 27 * DAY_IN_SECONDS;
+            $period = 'monthly';
+        } else if ($frequency == 'weekly') {
+            if ((int)date('w', $currentTimestamp) !== 1) {
+                return false;
+            }
+
+            $cutOut = 6 * DAY_IN_SECONDS;
+            $period = 'weekly';
+        } else if (isset($weekDays[$frequency])) {
+            if ((int)date('w', $currentTimestamp) !== $weekDays[$frequency]) {
+                return false;
+            }
+
+            $cutOut = 6 * DAY_IN_SECONDS;
+            $period = 'weekly';
+        } else {
             return false;
         }
 
         $lastSent = get_option('_fls_last_digest_sent', 0);
 
-        if ($lastSent && (current_time('timestamp') - strtotime($lastSent)) < $cutOut) {
+        if ($lastSent && ($currentTimestamp - strtotime($lastSent)) < $cutOut) {
             return false;
         }
 
         if (!$lastSent) {
-            $lastSent = date('Y-m-d H:i:s', current_time('timestamp') - $cutOut);
+            $lastSent = date('Y-m-d H:i:s', $currentTimestamp - $cutOut);
         }
 
         $counts = flsDb()->table('fls_auth_logs')
@@ -237,12 +256,6 @@ class BasicTasksHandler
 
         if (!$validItems) {
             return false;
-        }
-
-        $period = $frequency;
-
-        if (!in_array($frequency, ['monthly', 'weekly'])) {
-            $period = 'daily';
         }
 
         $infoHtml = '<ul style="padding-left:20px;line-height:25px;font-size: 14px;background: #f9f9f9;padding-top: 20px;padding-bottom: 20px;font-family: monospace;">';

--- a/src/admin/Components/Setttings.vue
+++ b/src/admin/Components/Setttings.vue
@@ -130,7 +130,7 @@
                             </el-col>
                             <el-col :sm="24" :md="12">
                                 <el-form-item
-                                    v-if="settings.notification_user_roles.length || settings.notify_on_blocked == 'yes' || settings.digest_summary">
+                                    v-if="settings.notification_user_roles.length || settings.notify_on_blocked == 'yes' || (settings.digest_summary && settings.digest_summary != 'none')">
                                     <template #label>
                                         {{ $t('Notification Send to Email Address') }}
                                         <el-tooltip
@@ -159,7 +159,7 @@
                                 </el-form-item>
                                 <el-form-item :label="$t('Send Digest Email Report Summary')">
                                     <el-select v-model="settings.digest_summary">
-                                        <el-option value="" :label="$t('Do not send digest email summary')"></el-option>
+                                        <el-option value="none" :label="$t('Do not send digest email summary')"></el-option>
                                         <el-option v-for="(day, dayName) in digest_items" :value="dayName" :label="day"></el-option>
                                     </el-select>
                                 </el-form-item>
@@ -272,6 +272,9 @@ export default {
                 .then(response => {
                     console.log(response);
                     this.settings = response.settings;
+                    if (!this.settings.digest_summary) {
+                        this.settings.digest_summary = 'none';
+                    }
                     this.user_roles = response.user_roles;
                     this.low_level_roles = response.low_level_roles;
                     this.app_ready = true;
@@ -292,6 +295,9 @@ export default {
                 .then(response => {
                     this.$notify.success(response.message);
                     this.settings = response.settings;
+                    if (!this.settings.digest_summary) {
+                        this.settings.digest_summary = 'none';
+                    }
                     this.appVars.auth_settings = response.settings;
                 })
                 .catch((errors) => {


### PR DESCRIPTION
Fix the digest email issue where it ignored the selected option and only used daily, weekly, or monthly. It now supports all options available in the dropdown.