### PR TITLE
Add server-side auto-redirect for logged-in users on auth shortcodes

### DIFF
--- a/app/Hooks/Handlers/CustomAuthHandler.php
+++ b/app/Hooks/Handlers/CustomAuthHandler.php
@@ -30,6 +30,7 @@ class CustomAuthHandler
         add_action('wp_ajax_nopriv_fluent_auth_rp', array($this, 'handlePasswordResentAjax'));
         add_action('fls_load_login_helper', array($this, 'loadAssets'));
         add_action('template_redirect', array($this, 'maybeRedirectLoggedIn'));
+        add_filter('do_shortcode_tag', array($this, 'maybeRedirectLoggedInViaJs'), 10, 3);
     }
 
     public function alterLoginRedirectUrl($redirect_to, $intentRedirectTo, $user)
@@ -607,6 +608,46 @@ class CustomAuthHandler
             wp_safe_redirect($redirect);
             exit;
         }
+    }
+
+    /**
+     * JS-based fallback for cases the `template_redirect` hook can't see — e.g.
+     * shortcodes rendered by page builders, widgets, or AJAX, where the
+     * shortcode isn't present in `$post->post_content`. Replaces the
+     * "already logged in" message output with an inline redirect script.
+     *
+     * @param string $output The rendered shortcode output.
+     * @param string $tag    The shortcode tag.
+     * @param array|string $attr The shortcode attributes ('' when none given).
+     * @return string
+     */
+    public function maybeRedirectLoggedInViaJs($output, $tag, $attr)
+    {
+        $authTags = [
+            'fluent_auth',
+            'fluent_auth_login',
+            'fluent_auth_signup',
+            'fluent_auth_reset_password',
+            'fluent_auth_magic_login',
+        ];
+
+        if (!in_array($tag, $authTags, true) || !is_user_logged_in()) {
+            return $output;
+        }
+
+        if (!is_array($attr)) {
+            return $output;
+        }
+
+        $redirect = $this->resolveAutoRedirectUrl($this->getShortcodes($attr));
+        if (!$redirect) {
+            return $output;
+        }
+
+        return sprintf(
+            '<script type="text/javascript">window.location.replace(%s);</script>',
+            wp_json_encode(esc_url_raw($redirect))
+        );
     }
 
     /**

--- a/app/Hooks/Handlers/CustomAuthHandler.php
+++ b/app/Hooks/Handlers/CustomAuthHandler.php
@@ -29,6 +29,7 @@ class CustomAuthHandler
         add_action('wp_ajax_nopriv_fluent_auth_signup', array($this, 'handleSignupAjax'));
         add_action('wp_ajax_nopriv_fluent_auth_rp', array($this, 'handlePasswordResentAjax'));
         add_action('fls_load_login_helper', array($this, 'loadAssets'));
+        add_action('template_redirect', array($this, 'maybeRedirectLoggedIn'));
     }
 
     public function alterLoginRedirectUrl($redirect_to, $intentRedirectTo, $user)
@@ -526,8 +527,10 @@ class CustomAuthHandler
             $redirectTo = home_url(Arr::get($_SERVER, 'REQUEST_URI'));
             $attributes['redirect_to'] = $redirectTo;
         } else if ($redirectTo) {
-            // Validate URL
-            if (!filter_var($redirectTo, FILTER_VALIDATE_URL)) {
+            // Allow site-relative paths like "/account"; FILTER_VALIDATE_URL would otherwise reject them for lacking a scheme. Leading "//" check guards against protocol-relative URLs.
+            if (strpos($redirectTo, '/') === 0 && strpos($redirectTo, '//') !== 0) {
+                $attributes['redirect_to'] = home_url($redirectTo);
+            } else if (!filter_var($redirectTo, FILTER_VALIDATE_URL)) {
                 $attributes['redirect_to'] = '';
             }
         }
@@ -555,6 +558,74 @@ class CustomAuthHandler
             }
             die();
         }
+    }
+
+    /**
+     * Server-side redirect for logged-in users landing on a page whose content
+     * contains an auth-form shortcode with `auto-redirect="true"`. Runs before
+     * any output so we can issue a proper 302 instead of relying on JS.
+     */
+    public function maybeRedirectLoggedIn()
+    {
+        if (is_admin() || !is_user_logged_in() || !is_singular() || wp_is_json_request()) {
+            return;
+        }
+
+        global $post;
+        if (!($post instanceof \WP_Post) || empty($post->post_content)) {
+            return;
+        }
+
+        $shortcodes = [
+            'fluent_auth',
+            'fluent_auth_login',
+            'fluent_auth_signup',
+            'fluent_auth_reset_password',
+            'fluent_auth_magic_login',
+        ];
+
+        foreach ($shortcodes as $tag) {
+            if (!has_shortcode($post->post_content, $tag)) {
+                continue;
+            }
+
+            $pattern = '/' . get_shortcode_regex([$tag]) . '/s';
+            if (!preg_match($pattern, $post->post_content, $matches)) {
+                continue;
+            }
+
+            $rawAttributes = shortcode_parse_atts($matches[3]);
+            if (!is_array($rawAttributes)) {
+                continue;
+            }
+
+            $redirect = $this->resolveAutoRedirectUrl($this->getShortcodes($rawAttributes));
+            if (!$redirect) {
+                continue;
+            }
+
+            wp_safe_redirect($redirect);
+            exit;
+        }
+    }
+
+    /**
+     * @param array $parsed Shortcode attributes already passed through getShortcodes().
+     * @return string Empty when redirect is disabled, missing, or invalid.
+     */
+    protected function resolveAutoRedirectUrl($parsed)
+    {
+        $autoRedirect = Arr::get($parsed, 'auto-redirect');
+        if ($autoRedirect !== 'true' && $autoRedirect !== true) {
+            return '';
+        }
+
+        $redirectTo = Arr::get($parsed, 'redirect_to');
+        if (!$redirectTo) {
+            return '';
+        }
+
+        return Helper::getValidatedRedirectUrl($redirectTo, '');
     }
 
     public function loadAssets($hide = '')


### PR DESCRIPTION
## Summary

The `auto-redirect` shortcode attribute existed in `getShortcodes()` defaults but was unreachable: the `handleAlreadyLoggedIn()` method that consumed it runs only *after* the logged-in early returns in `loginForm()` / `registrationForm()` / `restPasswordForm()` / `authForm()` / `magicLoginForm()`, so it never fired. This PR makes the attribute work via a server-side hook with a JS fallback for renderers that bypass `the_content`.

## Changes (purely additive)

- **Primary: `template_redirect` hook (`maybeRedirectLoggedIn`)** — scans the queried post for any of the 5 auth shortcodes, parses attributes, validates `redirect_to` through `Helper::getValidatedRedirectUrl()` (uses `wp_validate_redirect`, so open-redirects are blocked), and calls `wp_safe_redirect()` + `exit` before any output. Proper HTTP 302, no JS, no content flash.
- **Fallback: `do_shortcode_tag` filter (`maybeRedirectLoggedInViaJs`)** — for shortcodes rendered outside `the_content` (page builders, widget areas, AJAX). After the shortcode renders, if the user is logged in and `auto-redirect` is set with a valid `redirect_to`, replaces the output with an inline `<script>window.location.replace(...)</script>` that fires as soon as the parser hits it.
- **`resolveAutoRedirectUrl()` helper** — shared validation/extraction used by both hooks.
- **`getShortcodes()` accepts site-relative paths** (e.g. `/account`): `FILTER_VALIDATE_URL` rejects schemeless values, so paths were being wiped to empty. Now resolved through `home_url()`. A leading-`//` check rejects protocol-relative URLs masquerading as paths.

The 5 logged-in branches in the shortcode methods, the `handleAlreadyLoggedIn()` method, and the `fluent_auth/already_logged_in_message` filter are unchanged.

## Usage

```
[fluent_auth_login auto-redirect="true" redirect_to="/dashboard"]
[fluent_auth_login auto-redirect="true" redirect_to="https://site.com/dashboard"]
[fluent_auth auto-redirect="true" redirect_to="self"]
```

`redirect_to="self"` resolves to the current request URI (existing behavior).

## Coverage

| Render path | Behavior |
|---|---|
| Shortcode in `post_content` | Server-side 302 (no flash) |
| Page builder / widget / AJAX rendering via `do_shortcode()` | Inline JS redirect (replaces output) |
| `auto-redirect` not set, or invalid `redirect_to` | Existing "already logged in" message |

## Test plan

- [ ] Logged-in user visits page with `[fluent_auth_login auto-redirect="true" redirect_to="/dashboard"]` in post content → server-side 302 to `/dashboard` before any HTML.
- [ ] Same shortcode placed via a page builder widget → JS-based redirect kicks in.
- [ ] Same shortcode without `auto-redirect` → existing "already logged in" message (filter still applies).
- [ ] Logged-out user → form renders normally (no regression).
- [ ] `redirect_to="/account"` → resolves to `home_url('/account')` and redirects.
- [ ] `redirect_to="//evil.example.com/x"` → treated as URL (not path), fails `wp_validate_redirect`, no redirect.
- [ ] `redirect_to="https://external.example.com/x"` (not in `allowed_redirect_hosts`) → no redirect (open-redirect protection).
- [ ] `composer phpstan` clean.