### PR TITLE
Fix: Password reset email link

### DIFF
--- a/app/Services/SystemEmailService.php
+++ b/app/Services/SystemEmailService.php
@@ -296,7 +296,7 @@ class SystemEmailService
             <p>This password reset link will expire in 24 hours for security reasons.</p>
             <p>If you're having trouble with the button above, copy and paste the URL below into your web browser:</p>
             <blockquote>
-                <p>{{##user.password_reset_url##}}</p>
+                <p>{{user.password_reset_url}}</p>
             </blockquote>
             <hr/>
             <p>If you did not initiate this request, please review your account security and consider changing your


### PR DESCRIPTION
What was the issue: In the password reset email template (app/Services/SystemEmailService.php:299), the fallback URL placeholder was written as {{##user.password_reset_url##}} instead of {{user.password_reset_url}} or  ##user.password_reset_url## , resulting wrong URL in email notification.

Screenshot: https://prnt.sc/fWICQR2N6WNC

All other placeholders in the template system use the {{token}} or ##token## syntax (e.g. {{user.display_name}}, {{site.name}}, {{user.user_email}}). The extra ## markers were not matched by the token replacement logic, so the raw placeholder string was rendered in the email instead of the actual reset URL. Users who tried to copy/paste the fallback link (when the button didn't work) saw the literal template token and couldn't reset their password.                                   
                  
Change: 
{{##user.password_reset_url##}}  ->  {{user.password_reset_url}}