### PR TITLE
Fix: Google One Tap login redirect

### DIFF
--- a/app/Hooks/Handlers/GoogleOneTapAuthHandler.php
+++ b/app/Hooks/Handlers/GoogleOneTapAuthHandler.php
@@ -221,7 +221,7 @@ class GoogleOneTapAuthHandler
         ]);
 
         wp_localize_script('fluent-auth-google-one-tap', 'fluentOneTapConfig', [
-            'type'      => $args['type'],
+            'mode'      => $args['type'],
             'delay'     => intval($args['delay']),
             'client_id' => $config['google_client_id'],
             'ajax_url'  => admin_url('admin-ajax.php'),


### PR DESCRIPTION
The One Tap script reads fluentOneTapConfig.mode, but the config was localized as 'type'. The posted mode was always "undefined", so the inline button never matched the 'inline' check in handleGoogleOneTapLogin() and its redirect was overwritten with the current page URL, discarding the configured login redirect.