### PR TITLE
Fix: Social signup button redirect

### DIFF
--- a/app/Hooks/Handlers/SocialAuthHandler.php
+++ b/app/Hooks/Handlers/SocialAuthHandler.php
@@ -24,7 +24,7 @@ class SocialAuthHandler
         add_filter('login_form_bottom', [$this, 'maybePushToCustomForm']);
 
         add_filter('fluent_support/before_registration_form_close', [$this, 'maybePushRegistrationField']);
-        add_filter('fluent_auth/after_registration_form_close', [$this, 'maybePushRegistrationField']);
+        add_filter('fluent_auth/after_registration_form_close', [$this, 'maybePushRegistrationField'], 10, 3);
     }
 
     public function maybeSocialAuth()
@@ -487,22 +487,31 @@ class SocialAuthHandler
         $this->loadCss();
     }
 
-    public function maybePushRegistrationField($html)
+    public function maybePushRegistrationField($html, $registrationFields = [], $attributes = [])
     {
         if (!$this->isEnabled()) {
             return $html;
         }
 
+        $redirect = '';
+        if (!empty($attributes['redirect_to']) && filter_var($attributes['redirect_to'], FILTER_VALIDATE_URL)) {
+            $redirect = $attributes['redirect_to'];
+        }
+
         ob_start();
-        $this->initSignupButtonLoads();
+        $this->initSignupButtonLoads('fm_signup_with_wrap', 'block', $redirect);
         $content = ob_get_clean();
 
         return $html . $content;
     }
 
-    private function initSignupButtonLoads($selector = 'fm_signup_with_wrap', $display = 'block')
+    private function initSignupButtonLoads($selector = 'fm_signup_with_wrap', $display = 'block', $redirect = '')
     {
-        $buttons = $this->getSocialAuthButtons(wp_login_url(), __('Signup with', 'fluent-security'));
+        if (!$redirect) {
+            $redirect = apply_filters('fluent_auth/social_redirect_to', admin_url());
+        }
+
+        $buttons = $this->getSocialAuthButtons($redirect, __('Signup with', 'fluent-security'));
 
         if (!$this->isEnabled('google')) {
             unset($buttons['google']);


### PR DESCRIPTION
What was the issue: Signing up with a social provider always ignored the redirect destination. The signup social buttons hardcoded `wp_login_url()` as their redirect intent (app/Hooks/Handlers/SocialAuthHandler.php:505), so a first-time Google/GitHub/Facebook signup landed on wp-login.php regardless of the shortcode's `redirect_to` attribute or the configured Login Redirects destination. The user is actually authenticated at that point (the auth cookie is set by AuthService::makeLogin()), but wp-login.php renders the login form, so it looks like the signup failed.

Two separate causes:

1. The shortcode's `redirect_to` never reached the buttons. `[fluent_auth_signup]` passes its attributes to `fluent_auth/after_registration_form_close` (app/Hooks/Handlers/CustomAuthHandler.php:214), but the filter was registered with the default arity, so `$attributes` was dropped before `maybePushRegistrationField()` could read it. The login buttons have no such problem: the login shortcode registers a `fluent_auth/social_redirect_to` filter which `pushLoginWithButtons()` applies.

2. The fallback was wrong. `alterLoginRedirectUrl()` (app/Hooks/Handlers/CustomAuthHandler.php:52) only applies the Login Redirects settings when the candidate URL contains `/wp-admin`; any other URL is treated as a destination the site owner chose deliberately. `wp_login_url()` is a frontend URL by that test, so it suppressed the settings entirely. Every other auth path in the plugin defaults to `admin_url()` for exactly this reason: regular login (CustomAuthHandler.php:719), signup auto-login (CustomAuthHandler.php:900), and Google One Tap (GoogleOneTapAuthHandler.php:112). The social signup buttons were the only outlier, which is why email/password signup honours the Login Redirects settings but social signup did not.

Change:

- Register `fluent_auth/after_registration_form_close` with arity 3 so `$attributes` is passed through.
- Widen `maybePushRegistrationField()` to read `redirect_to` from `$attributes` and hand it to `initSignupButtonLoads()`.
- `initSignupButtonLoads()` accepts the redirect and falls back to `apply_filters('fluent_auth/social_redirect_to', admin_url())`.

Redirect precedence for the signup buttons is now shortcode `redirect_to`, then the `fluent_auth/social_redirect_to` filter, then the Login Redirects settings, then the WordPress default. This matches the login buttons.

Backwards compatibility: widening a filter callback's arity is safe, and the two other callers are unaffected. `fluent_support/before_registration_form_close` still passes one argument and picks up the fallback via the parameter defaults. `pushRegisterWithButtons()` (the wp-login.php?action=register form) also uses the fallback, which brings it in line with the login form rendered on the same screen.

Verified on a local site with Login Redirects enabled: the signup button's `intent_redirect_to` now carries the shortcode's URL when one is set, and `admin_url()` otherwise, which `alterLoginRedirectUrl()` rewrites to the configured default destination.
